### PR TITLE
fixed build errors and warnings in latest react-native and gradle version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,5 +15,5 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         ndk {


### PR DESCRIPTION
- Replaced reference to buildtools version, since each andrpod gradle plugin version now has a default one
- Updated compileSdkVersion and targetSdkVersion
- Replaced compile with implementation in build.gradle to stop warning