### PR TITLE
Fix validation errors in podspec

### DIFF
--- a/ios/RNKeyEvent.podspec
+++ b/ios/RNKeyEvent.podspec
@@ -2,11 +2,11 @@
 Pod::Spec.new do |s|
   s.name         = "RNKeyEvent"
   s.version      = "1.0.0"
-  s.summary      = "RNKeyEvent"
+  s.summary      = "Listen to keyboard events"
   s.description  = <<-DESC
                   RNKeyEvent
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/kevinejohn/react-native-keyevent"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
Cocoapods complains about an empty value for the "homepage" attribute, and that summary and description is equal.

It also complains that there is no version included in the git tag, but I see how it's convenient to not have to update it, so I left it as it is since it's just a warning, not an error.