### PR TITLE
Add defensive check for Android bridge communicator instance

### DIFF
--- a/android/src/main/java/com/github/kevinejohn/keyevent/KeyEventModule.java
+++ b/android/src/main/java/com/github/kevinejohn/keyevent/KeyEventModule.java
@@ -28,6 +28,10 @@ public class KeyEventModule extends ReactContextBaseJavaModule {
     }
 
     public void onKeyDownEvent(int keyCode, KeyEvent keyEvent) {
+        if (!mReactContext.hasActiveCatalystInstance()) {
+            return;
+        }
+
         if (mJSModule == null) {
             mJSModule = mReactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class);
         }
@@ -35,6 +39,10 @@ public class KeyEventModule extends ReactContextBaseJavaModule {
     };
 
     public void onKeyUpEvent(int keyCode, KeyEvent keyEvent) {
+        if (!mReactContext.hasActiveCatalystInstance()) {
+            return;
+        }
+
         if (mJSModule == null) {
             mJSModule = mReactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class);
         }
@@ -42,6 +50,10 @@ public class KeyEventModule extends ReactContextBaseJavaModule {
     };
 
     public void onKeyMultipleEvent(int keyCode, int repeatCount, KeyEvent keyEvent) {
+        if (!mReactContext.hasActiveCatalystInstance()) {
+            return;
+        }
+        
         if (mJSModule == null) {
             mJSModule = mReactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class);
         }


### PR DESCRIPTION
- Adds checks to the keyEvent methods that verifies that the communication mechanism over the bridge is attached before attempting to send such keyEvents.