### PR TITLE
Add react-native.config.js for rnpm error on metro bundler

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  project: {
+    android: {
+      "packageInstance": "new KeyEventPackage()"
+    }
+  }
+}


### PR DESCRIPTION
Adding a `react-native.config.js` file to remove alert error about rnpm info in package.json