### PR TITLE
fix: bump android min sdk version to 21 to support latest rn

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 31
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 31
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
While clean building and refreshing the dependencies for libraries in RN Android using `./gradlew clean build --refresh-dependencies`, noticed an issue with react-native-keyevent package in react-native version `0.71.6`. 
This is the error:
`/node_modules/react-native-keyevent/android/build/intermediates/tmp/manifest/androidTest/debug/tempFile1ProcessTestManifest18054783116315339840.xml:5:5-74 Error:
        uses-sdk:minSdkVersion 16 cannot be smaller than version 21 declared in library [com.facebook.react:react-android:0.71.6] /Users/debjitroy/.gradle/caches/transforms-3/a23800d9c4fddb71901c930343e4fa9a/transformed/jetified-react-android-0.71.6-debug/AndroidManifest.xml as the library might be using APIs not available in 16
        Suggestion: use a compatible library with a minSdk of at most 16,
                or increase this project's minSdk version to at least 21,
                or use tools:overrideLibrary="com.facebook.react" to force usage (may lead to runtime failures)
In this PR, bumping up minimum version to 21. `
Locally, bumping up the minSDK version to 21 made the build success, so creating this PR with the same change