### PR TITLE
Preventing too early events

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,55 +92,60 @@ Implement onConfigurationChanged method in MainActivity.java
       ......
       @Override  // <--- Add this method if you want to react to keyDown
       public boolean onKeyDown(int keyCode, KeyEvent event) {
-
-        // A. Prevent multiple events on long button press
-        //    In the default behavior multiple events are fired if a button
-        //    is pressed for a while. You can prevent this behavior if you
-        //    forward only the first event:
-        //        if (event.getRepeatCount() == 0) {
-        //            KeyEventModule.getInstance().onKeyDownEvent(keyCode, event);
-        //        }
-        //
-        // B. If multiple Events shall be fired when the button is pressed
-        //    for a while use this code:
-        //        KeyEventModule.getInstance().onKeyDownEvent(keyCode, event);
-        //
-        // Using B.
-        KeyEventModule.getInstance().onKeyDownEvent(keyCode, event);
-
-        // There are 2 ways this can be done:
-        //  1.  Override the default keyboard event behavior
-        //    super.onKeyDown(keyCode, event);
-        //    return true;
-
-        //  2.  Keep default keyboard event behavior
-        //    return super.onKeyDown(keyCode, event);
-
-        // Using method #1 without blocking multiple
+        if(KeyEventModule.getInstance() != null) {
+            // A. Prevent multiple events on long button press
+            //    In the default behavior multiple events are fired if a button
+            //    is pressed for a while. You can prevent this behavior if you
+            //    forward only the first event:
+            //        if (event.getRepeatCount() == 0) {
+            //            KeyEventModule.getInstance().onKeyDownEvent(keyCode, event);
+            //        }
+            //
+            // B. If multiple Events shall be fired when the button is pressed
+            //    for a while use this code:
+            //        KeyEventModule.getInstance().onKeyDownEvent(keyCode, event);
+            //
+            // Using B.
+            KeyEventModule.getInstance().onKeyDownEvent(keyCode, event);
+    
+            // There are 2 ways this can be done:
+            //  1.  Override the default keyboard event behavior
+            //    super.onKeyDown(keyCode, event);
+            //    return true;
+    
+            //  2.  Keep default keyboard event behavior
+            //    return super.onKeyDown(keyCode, event);
+    
+            // Using method #1 without blocking multiple
+        }
         super.onKeyDown(keyCode, event);
         return true;
       }
 
       @Override  // <--- Add this method if you want to react to keyUp
       public boolean onKeyUp(int keyCode, KeyEvent event) {
-        KeyEventModule.getInstance().onKeyUpEvent(keyCode, event);
-
-        // There are 2 ways this can be done:
-        //  1.  Override the default keyboard event behavior
-        //    super.onKeyUp(keyCode, event);
-        //    return true;
-
-        //  2.  Keep default keyboard event behavior
-        //    return super.onKeyUp(keyCode, event);
-
-        // Using method #1
+        if(KeyEventModule.getInstance() != null) {
+            KeyEventModule.getInstance().onKeyUpEvent(keyCode, event);
+    
+            // There are 2 ways this can be done:
+            //  1.  Override the default keyboard event behavior
+            //    super.onKeyUp(keyCode, event);
+            //    return true;
+    
+            //  2.  Keep default keyboard event behavior
+            //    return super.onKeyUp(keyCode, event);
+    
+            // Using method #1
+        }
         super.onKeyUp(keyCode, event);
         return true;
       }
 
       @Override
       public boolean onKeyMultiple(int keyCode, int repeatCount, KeyEvent event) {
-          KeyEventModule.getInstance().onKeyMultipleEvent(keyCode, repeatCount, event);
+          if(KeyEventModule.getInstance() != null) {
+              KeyEventModule.getInstance().onKeyMultipleEvent(keyCode, repeatCount, event);
+          }
           return super.onKeyMultiple(keyCode, repeatCount, event);
       }
       ......


### PR DESCRIPTION
When the app is opened using either the volume up or volume down buttons, it will crash because the module hasn’t been initialized yet. 📲💥

Related issue #86 